### PR TITLE
Increase defaults

### DIFF
--- a/apex.yaml
+++ b/apex.yaml
@@ -4,7 +4,7 @@ demultiplex:
   version: "v0.1.1"
   description: "SparkDs fork of nf-core/demultiplex"
   workspace_id: "115437722032750"
-  compute_env_id: "60CuzbBLqIizMj0jEJvoL4"
+  compute_env_id: "1SepHXjkNIFllfRsNfVTsH"
   output_bucket: "sparkds-nextflow-outputs-production"
   pipeline_admins:
     - "mark.welsh@sparktx.com"

--- a/conf/base.config
+++ b/conf/base.config
@@ -35,9 +35,9 @@ process {
         time   = { check_max( 8.h   * task.attempt, 'time'    ) }
     }
     withLabel:process_high {
-        cpus   = { check_max( 12    * task.attempt, 'cpus'    ) }
-        memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 16.h  * task.attempt, 'time'    ) }
+        cpus   = { check_max( 24     * task.attempt, 'cpus'    ) }
+        memory = { check_max( 144.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 24.h   * task.attempt, 'time'    ) }
     }
     withLabel:process_long {
         time   = { check_max( 20.h  * task.attempt, 'time'    ) }
@@ -50,7 +50,7 @@ process {
     }
     withLabel:error_retry {
         errorStrategy = 'retry'
-        maxRetries    = 2
+        maxRetries    = 4
     }
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {
         cache = false

--- a/modules/nf-core/bclconvert/main.nf
+++ b/modules/nf-core/bclconvert/main.nf
@@ -1,6 +1,7 @@
 process BCLCONVERT {
     tag {"$meta.lane" ? "$meta.id"+"."+"$meta.lane" : "$meta.id" }
     label 'process_high'
+    label 'error_retry'
 
     container "nfcore/bclconvert:4.0.3"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,8 +59,8 @@ params {
 
     // Max resource options
     // Defaults only, expecting to be overwritten
-    max_memory                  = '128.GB'
-    max_cpus                    = 16
+    max_memory                  = '512.GB'
+    max_cpus                    = 64
     max_time                    = '240.h'
 
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -132,7 +132,7 @@
                 "max_cpus": {
                     "type": "integer",
                     "description": "Maximum number of CPUs that can be requested for any single job.",
-                    "default": 16,
+                    "default": 64,
                     "fa_icon": "fas fa-microchip",
                     "hidden": true,
                     "help_text": "Use to set an upper-limit for the CPU requirement for each process. Should be an integer e.g. `--max_cpus 1`"
@@ -140,7 +140,7 @@
                 "max_memory": {
                     "type": "string",
                     "description": "Maximum amount of memory that can be requested for any single job.",
-                    "default": "128.GB",
+                    "default": "512.GB",
                     "fa_icon": "fas fa-memory",
                     "pattern": "^\\d+(\\.\\d+)?\\.?\\s*(K|M|G|T)?B$",
                     "hidden": true,

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -165,7 +165,7 @@ workflow DEMULTIPLEX {
 
     // MODULE: md5sum
     // Split file list into separate channels entries and generate a checksum for each
-    MD5SUM(ch_fastq_to_qc.transpose())
+    // MD5SUM(ch_fastq_to_qc.transpose())
 
     // DUMP SOFTWARE VERSIONS
     CUSTOM_DUMPSOFTWAREVERSIONS (


### PR DESCRIPTION
- turns off MD5SUM
- gives it more juice by default
- allows big jobs to fail, expand, and retry at larger scale
- change to a compute env that actually uses Fusion