### PR TITLE
Attempt to handle empty FASTQs prior to MultiQC

### DIFF
--- a/modules/nf-core/multiqc/environment.yml
+++ b/modules/nf-core/multiqc/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::multiqc=1.19
+  - bioconda::multiqc=1.21

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -3,8 +3,8 @@ process MULTIQC {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.19--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.19--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.21--pyhdfd78af_0' :
+        'biocontainers/multiqc:1.21--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"

--- a/subworkflows/nf-core/bcl_demultiplex/main.nf
+++ b/subworkflows/nf-core/bcl_demultiplex/main.nf
@@ -81,7 +81,8 @@ workflow BCL_DEMULTIPLEX {
 // Add meta values to fastq channel
 def generate_fastq_meta(ch_reads) {
     // Create a tuple with the meta.id and the fastq
-    ch_reads.transpose().map { fc_meta, fastq ->
+    ch_reads.transpose().map{
+        fc_meta, fastq ->
         def meta = [
             "id": fastq.getSimpleName().toString() - ~/_R[0-9]_001.*$/,
             "samplename": fastq.getSimpleName().toString() - ~/_S[0-9]+.*$/,


### PR DESCRIPTION
This aims to resolve an edge case where FASTQs are completely empty - no reads at all. Some experimental libraries may see this and there is no existing switch to handle this. We still want these FASTQs, but the nf-core pipeline fails fatally if no read group is found. Such is the case with empty FASTQs.

Side effect: no multiqc will run on this FASTQs, but who cares, you can't QC an empty file